### PR TITLE
Test python3 in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,27 @@ python:
   - "3.5"
   - "3.6"
 
+env:
+  - DJANGO=1.8
+  - DJANGO=1.9
+  - DJANGO=1.10
+  - DJANGO=1.11
+  - DJANGO=master
+
+matrix:
+    fast_finish: true
+    exclude:
+      - python: "2.7"
+        env: DJANGO=master
+      - python: "3.4"
+        env: DJANGO=master
+      - python: "3.6"
+        env: DJANGO=1.8
+      - python: "3.6"
+        env: DJANGO=1.9
+      - python: "3.6"
+        env: DJANGO=1.10
+
 install: pip install tox-travis
 
 script: tox

--- a/tox.ini
+++ b/tox.ini
@@ -1,20 +1,39 @@
 [tox]
-envlist = py27, py34, py35, py36
+envlist =
+       {py27,py33,py34,py35}-django18,
+       {py27,py34,py35}-django{19,110},
+       {py27,py34,py35,py36}-django111,
+       {py35,py36}-djangomaster
+
+[travis:env]
+DJANGO =
+    1.8: django18
+    1.9: django19
+    1.10: django110
+    1.11: django111
+    master: djangomaster
 
 [testenv]
 basepython =
     py27: python2.7
+    py33: python3.3
     py34: python3.4
     py35: python3.5
     py36: python3.6
+
 deps =
-    Django>=1.8,<1.11
+    django18: Django>=1.8,<1.9
+    django19: Django>=1.9,<1.10
+    django110: Django>=1.10,<1.11
+    django111: Django>=1.11rc1,<2.0
+    djangomaster: https://github.com/django/django/archive/master.tar.gz
     check-manifest
     flake8
     readme_renderer
     mock
     pytest-runner
     pytest
+
 commands =
     check-manifest --ignore tox.ini,tests*
     {envpython} setup.py check -m -r -s


### PR DESCRIPTION
# Overview
Update the TravisCI build matrix to test django 1.8-1.11 with all of their dependencies.

# Testing: 
See https://travis-ci.org/azavea/django-amazon-ses/builds/216082261

Fixes #5 