### PR TITLE
Add setting for AWS region configuration

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -56,6 +56,12 @@ Lastly, override the ``EMAIL_BACKEND`` setting within your Django settings file:
 
    EMAIL_BACKEND = 'django_amazon_ses.backends.boto.EmailBackend'
 
+Optionally, you can set the AWS region to be used (default is ``'us-east-1'``):
+
+.. code:: python
+
+   DJANGO_AMAZON_SES_REGION = 'eu-west-1'
+
 Signals
 -------
 

--- a/django_amazon_ses/backends/boto.py
+++ b/django_amazon_ses/backends/boto.py
@@ -3,6 +3,7 @@ import boto3
 
 from botocore.exceptions import ClientError
 
+from django.conf import settings
 from django.core.mail.backends.base import BaseEmailBackend
 from django.core.mail.message import sanitize_address
 from django.dispatch import Signal
@@ -17,7 +18,7 @@ class EmailBackend(BaseEmailBackend):
     Attributes:
         conn: A client connection for Amazon SES.
     """
-    def __init__(self, region_name='us-east-1', fail_silently=False, **kwargs):
+    def __init__(self, region_name=None, fail_silently=False, **kwargs):
         """Creates a client for the Amazon SES API.
 
         Args:
@@ -27,6 +28,12 @@ class EmailBackend(BaseEmailBackend):
 
         """
         super(EmailBackend, self).__init__(fail_silently=fail_silently)
+        if region_name is None:
+            region_name = getattr(
+                settings,
+                'DJANGO_AMAZON_SES_REGION',
+                'us-east-1'
+            )
         self.conn = boto3.client('ses', region_name=region_name)
 
     def send_messages(self, email_messages):


### PR DESCRIPTION
This adds an optional setting (DJANGO_AMAZON_SES_REGION) to allow for
the configuration of the AWS region SES should use. The default is left
at 'eu-central-1'.

It would take some structural revamping of the test suite to properly test this,
so I've skipped that bit for now... This has been tested in a deployed system
using eu-west-1.