### PR TITLE
Enable pip cache in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
-language: python
-
 sudo: false
+language: python
+cache: pip
 
 python:
   - "2.7"


### PR DESCRIPTION
Can slightly improve build times and reduce load on PyPI servers. For information on the Travis cache feature, see:

https://docs.travis-ci.com/user/caching/#pip-cache