### PR TITLE
Remove tox configuration of basepython as it is redundant

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -14,13 +14,6 @@ DJANGO =
     master: djangomaster
 
 [testenv]
-basepython =
-    py27: python2.7
-    py33: python3.3
-    py34: python3.4
-    py35: python3.5
-    py36: python3.6
-
 deps =
     django18: Django>=1.8,<1.9
     django19: Django>=1.9,<1.10


### PR DESCRIPTION
The configuration is simply respecifying tox default values. No need to repeat them in the `tox.ini`.

https://tox.readthedocs.io/en/latest/config.html#factors-and-factor-conditional-settings

> tox provides good defaults for basepython setting, so the above ini-file can be further reduced by omitting the basepython setting.