### PR TITLE
Avoid tests_require and EasyInstall instead of pip for installation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,6 @@ here = path.abspath(path.dirname(__file__))
 with open(path.join(here, 'README.rst'), encoding='utf-8') as f:
     long_description = f.read()
 
-tests_require = ['moto >= 0.4.23']
 
 setup(
     name='django-amazon-ses',
@@ -32,9 +31,4 @@ setup(
     keywords='django amazon ses email',
     packages=find_packages(exclude=['tests']),
     install_requires=['boto3 >= 1.3.0'],
-    extras_require={
-        'dev': [],
-        'test': tests_require,
-    },
-    tests_require=tests_require,
 )

--- a/tox.ini
+++ b/tox.ini
@@ -31,6 +31,7 @@ deps =
     flake8
     readme_renderer
     mock
+    moto>=0.4.23
     pytest-runner
     pytest
 


### PR DESCRIPTION
Packages installed through tests_require are not installed to the virtualenv.

https://setuptools.readthedocs.io/en/latest/setuptools.html#new-and-changed-setup-keywords

> tests_require
>
> If your project’s tests need one or more additional packages besides
> those needed to install it, you can use this option to specify them.
> It should be a string or list of strings specifying what other
> distributions need to be present for the package’s tests to run. When
> you run the test command, setuptools will attempt to obtain
> these (even going so far as to download them using EasyInstall). Note
> that these required projects will not be installed on the system where
> the tests are run, but only downloaded to the project’s setup
> directory if they’re not already installed locally.