### PR TITLE
Bump min Django 1.11 package to stable version

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ deps =
     django18: Django>=1.8,<1.9
     django19: Django>=1.9,<1.10
     django110: Django>=1.10,<1.11
-    django111: Django>=1.11rc1,<2.0
+    django111: Django>=1.11,<2.0
     djangomaster: https://github.com/django/django/archive/master.tar.gz
     check-manifest
     flake8


### PR DESCRIPTION
Unifies testing ranges.