### PR TITLE
Improve and simplify tox-travis usage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,30 +4,10 @@ cache: pip
 
 python:
   - "2.7"
+  - "3.3"
   - "3.4"
   - "3.5"
   - "3.6"
-
-env:
-  - DJANGO=1.8
-  - DJANGO=1.9
-  - DJANGO=1.10
-  - DJANGO=1.11
-  - DJANGO=master
-
-matrix:
-    fast_finish: true
-    exclude:
-      - python: "2.7"
-        env: DJANGO=master
-      - python: "3.4"
-        env: DJANGO=master
-      - python: "3.6"
-        env: DJANGO=1.8
-      - python: "3.6"
-        env: DJANGO=1.9
-      - python: "3.6"
-        env: DJANGO=1.10
 
 install: pip install tox-travis
 
@@ -42,5 +22,4 @@ deploy:
   on:
     tags: true
     python: "3.6"
-    condition: "$DJANGO = 1.11"
     repo: azavea/django-amazon-ses

--- a/tox.ini
+++ b/tox.ini
@@ -5,14 +5,6 @@ envlist =
        {py27,py34,py35,py36}-django111,
        {py35,py36}-djangomaster
 
-[travis:env]
-DJANGO =
-    1.8: django18
-    1.9: django19
-    1.10: django110
-    1.11: django111
-    master: djangomaster
-
 [testenv]
 deps =
     django18: Django>=1.8,<1.9


### PR DESCRIPTION
tox-travis automatically runs against all tox envs that have the Travis's Python version as a factor. There is no need to also specify the Django environment separately.

From https://tox-travis.readthedocs.io/en/stable/envlist.html

> Env detection is the primary feature of Tox-Travis. Based on the matrix created in `.travis.yml`, it decides which Tox envs need to be run for each Travis job.
>
> ...
>
> And it will run the appropriate testenvs, which by default are any declared env with [the travis Pythons] as factors of the name.

As a result, the Travis tests now include tests for the `py33-django18` env. It was previously missing from Travis but not tox.

You can observe the Travis output to see that it is running against all configured Django versions.