### PR TITLE
Don't configure a database for testing

### DIFF
--- a/tests/test_boto.py
+++ b/tests/test_boto.py
@@ -14,14 +14,7 @@ from django.test import SimpleTestCase
 
 from django_amazon_ses.backends.boto import pre_send
 
-settings.configure(
-    DATABASES={
-        "default": {
-            "ENGINE": "django.db.backends.sqlite3",
-            "NAME": ":memory:",
-        }
-    }
-)
+settings.configure()
 
 
 class MailTests(SimpleTestCase):


### PR DESCRIPTION
All tests run using `SimpleTestCase` and so should never access the database. Therefore, can avoid configuring one through settings.