### PR TITLE
Designate django-amazon-ses as stable and ready for production

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     author_email='hcastro@azavea.com',
     license='Apache License 2.0',
     classifiers=[
-        'Development Status :: 4 - Beta',
+        'Development Status :: 5 - Production/Stable',
         'Framework :: Django',
         'Framework :: Django :: 1.8',
         'Framework :: Django :: 1.9',


### PR DESCRIPTION
Helps give library users confidence that the project is maintained and ready for production use.