### PR TITLE
Remove tests* from check-manifest ignore; it is in the sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,5 @@
 include LICENSE.txt
 include CHANGELOG.rst
-
-recursive-include tests *
+graft tests
+global-exclude __pycache__
+global-exclude *.py[co]

--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,7 @@ deps =
     pytest
 
 commands =
-    check-manifest --ignore tox.ini,tests*
+    check-manifest --ignore tox.ini
     {envpython} setup.py check -m -r -s
     flake8 .
     {envpython} setup.py test


### PR DESCRIPTION
As tests are included in sdist, they should be checked by check-manifest.

Previously listed in `MANIFEST.in` as `recursive-include tests *`. Now use `graft` as the command to include entire directories.

To ignore the generated Python cache files during tox runs, added `global-exclude` commands.

https://docs.python.org/3/distutils/commandref.html