### PR TITLE
Allow setting credentials through settings.py

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,10 @@ UNRELEASED
 - Dropped support for Python 3.3.
 - Add testing and support for Django 2.0 (no actual code changes were
   required).
+- Add settings ``AWS_ACCESS_KEY_ID`` and ``AWS_SECRET_ACCESS_KEY`` to configure
+  credentials through ``settings.py``.
+- Rename setting ``DJANGO_AMAZON_SES_REGION`` to ``AWS_DEFAULT_REGION`` (to
+  match the Boto 3 environment variable).
 
 0.3.2
 =====

--- a/README.rst
+++ b/README.rst
@@ -56,11 +56,20 @@ Lastly, override the ``EMAIL_BACKEND`` setting within your Django settings file:
 
    EMAIL_BACKEND = 'django_amazon_ses.backends.boto.EmailBackend'
 
+Optionally, you can set the AWS credentials. If unset, the backend will
+gracefully fall back to other Boto 3 credential providers.
+
+.. code:: python
+
+   AWS_ACCESS_KEY_ID = 'my_access_key...'
+   AWS_SECRET_ACCESS_KEY = 'my_secret...'
+
+
 Optionally, you can set the AWS region to be used (default is ``'us-east-1'``):
 
 .. code:: python
 
-   DJANGO_AMAZON_SES_REGION = 'eu-west-1'
+   AWS_DEFAULT_REGION = 'eu-west-1'
 
 Signals
 -------

--- a/django_amazon_ses/backends/boto.py
+++ b/django_amazon_ses/backends/boto.py
@@ -18,23 +18,24 @@ class EmailBackend(BaseEmailBackend):
     Attributes:
         conn: A client connection for Amazon SES.
     """
-    def __init__(self, region_name=None, fail_silently=False, **kwargs):
+    def __init__(self, fail_silently=False, **kwargs):
         """Creates a client for the Amazon SES API.
 
         Args:
-            region_name: Amazon region for SES endpoint.
             fail_silently: Flag that determines whether Amazon SES
                 client errors should throw an exception.
 
         """
         super(EmailBackend, self).__init__(fail_silently=fail_silently)
-        if region_name is None:
-            region_name = getattr(
-                settings,
-                'DJANGO_AMAZON_SES_REGION',
-                'us-east-1'
-            )
-        self.conn = boto3.client('ses', region_name=region_name)
+        access_key_id = getattr(settings, 'AWS_ACCESS_KEY_ID', None)
+        secret_access_key = getattr(settings, 'AWS_SECRET_ACCESS_KEY', None)
+        region_name = getattr(settings, 'AWS_DEFAULT_REGION', 'us-east-1')
+        self.conn = boto3.client(
+            'ses',
+            aws_access_key_id=access_key_id,
+            aws_secret_access_key=secret_access_key,
+            region_name=region_name,
+        )
 
     def send_messages(self, email_messages):
         """Sends one or more EmailMessage objects and returns the


### PR DESCRIPTION
Support the setting `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` in `settings.py`. Use these to connect through boto3. The setting names are identical to the environment variable names. The names also match other AWS Django apps, such as django-storages.

Removed `region_name` as an argument to the backend as it is not a supported keyword argument of `BaseEmailBackend`. This value can still be set through settings.py.