### PR TITLE
Pin html5lib during tests to workaround bleach incompatibility

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -21,6 +21,11 @@ deps =
     moto>=0.4.23
     pytest-runner
     pytest
+    # Work around incompatability in bleach (required by readme_renderer) with
+    # the latest html5lib release. Remove html5lib once resolved. For
+    # additional details, see:
+    # https://github.com/mozilla/bleach/issues/337
+    html5lib==1.0b10
 
 commands =
     check-manifest --ignore tox.ini


### PR DESCRIPTION
A new version of html5lib was released. This version has some backwards incompatible changes. These changes broke readme_renderer's dependency, bleach. This is causing tests failures when running tox. To allow tests to pass, pin html5lib until the incompatibility has been resolved.

https://github.com/mozilla/bleach/issues/337