### PR TITLE
Drop workaround for Bleach incompatibility

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -21,11 +21,6 @@ deps =
     moto>=0.4.23
     pytest-runner
     pytest
-    # Work around incompatability in bleach (required by readme_renderer) with
-    # the latest html5lib release. Remove html5lib once resolved. For
-    # additional details, see:
-    # https://github.com/mozilla/bleach/issues/337
-    html5lib==1.0b10
 
 commands =
     check-manifest --ignore tox.ini


### PR DESCRIPTION
Bleach released a new version that is compatible with the new html5lib.