### PR TITLE
Add release dates to CHANGELOG.rst

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,5 @@
-1.0.0
-=====
+1.0.0 - 2017-12-07
+==================
 
 - Drop support for Python 3.3.
 - Add testing and support for Django 2.0 (no actual code changes were
@@ -18,57 +18,57 @@
   Importing signals should now be imported from ``django_amazon_ses`` instead
   of ``django_amazon_ses.backends.boto``.
 
-0.3.2
-=====
+0.3.2 - 2017-11-15
+==================
 
 - Fix Travis CI deployment process to account for wheels.
 - Ensure that only one element of the build matrix publishes to PyPI.
 
-0.3.1
-=====
+0.3.1 - 2017-11-15
+==================
 
 - Fix ``tox`` installation of test dependencies.
 - Add ``pip`` cache to Travis CI configuration.
 - Include license file in wheel package.
 
-0.3.0
------
+0.3.0 - 2017-03-30
+==================
 
 - Officially support Python 3.x.
 - Use a more sophisticated matrix build process to test Django compatibility.
 - Add support for ``DJANGO_AMAZON_SES_REGION`` setting.
 
-0.2.2
------
+0.2.2 - 2017-01-05
+==================
 
 - Functionally identical to ``0.2.0-0.2.1``, but includes a reStructuredText formatting change to the ``README`` for PyPi compatibility.
 
-0.2.1
------
+0.2.1 - 2017-01-05
+==================
 
 - Functionally identical to ``0.2.0``, but includes a reStructuredText formatting change to the ``README`` for PyPi compatibility.
 
-0.2.0
------
+0.2.0 - 2017-01-05
+==================
 
 - Add support for ``pre_send`` and ``post_send`` signals for email messages.
 
-0.1.3
------
+0.1.3 - 2016-03-23
+==================
 
 - Update PyPI credentials; functionally identical to ``0.1.0-0.1.2``.
 
-0.1.2
------
+0.1.2 - 2016-03-23
+==================
 
 - Functionally identical to ``0.1.0-0.1.1``, but actually updates ``setup.py``.
 
-0.1.1
------
+0.1.1 - 2016-03-23
+==================
 
 - Ensure that manifest accounts for ``CHANGELOG.rst``.
 
-0.1.0
------
+0.1.0 - 2016-03-23
+==================
 
 - Initial release.


### PR DESCRIPTION
Helps library users better understand when a change occurred. Follows recommendation from "Keep a CHANGELOG".

http://keepachangelog.com/

> The release date of each versions is displayed.

Discovered dates through PyPI and git tags.

Unified all release headers to a single style.