### PR TITLE
Added SES-specific settings

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,8 @@
+UNRELEASED - 2017-12-21
+=======================
+
+- Add option to use different AWS settings through ``AWS_SES_ACCESS_KEY_ID``, ``AWS_SES_SECRET_ACCESS_KEY``, ``AWS_SES_REGION``
+
 1.0.0 - 2017-12-07
 ==================
 

--- a/README.rst
+++ b/README.rst
@@ -71,6 +71,14 @@ Optionally, you can set the AWS region to be used (default is ``'us-east-1'``):
 
    AWS_DEFAULT_REGION = 'eu-west-1'
 
+Alternatively, instead of AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY and AWS_DEFAULT_REGION, you can include the following two settings values. This is useful in situations where you would like to use a separate access key to send emails via SES than you would to upload files via S3.
+
+.. code:: python
+
+    AWS_SES_ACCESS_KEY_ID = 'my_access_key...'
+    AWS_SES_SECRET_ACCESS_KEY = 'my_secret...'
+    AWS_SES_REGION = 'another region'
+
 Signals
 -------
 

--- a/django_amazon_ses.py
+++ b/django_amazon_ses.py
@@ -27,9 +27,9 @@ class EmailBackend(BaseEmailBackend):
 
         """
         super(EmailBackend, self).__init__(fail_silently=fail_silently)
-        access_key_id = getattr(settings, 'AWS_ACCESS_KEY_ID', None)
-        secret_access_key = getattr(settings, 'AWS_SECRET_ACCESS_KEY', None)
-        region_name = getattr(settings, 'AWS_DEFAULT_REGION', 'us-east-1')
+        access_key_id = getattr(settings, 'AWS_SES_ACCESS_KEY_ID', getattr(settings, 'AWS_ACCESS_KEY_ID', None))
+        secret_access_key = getattr(settings, 'AWS_SES_SECRET_ACCESS_KEY', getattr(settings, 'AWS_SECRET_ACCESS_KEY', None))
+        region_name = getattr(settings, 'AWS_SES_REGION', getattr(settings, 'AWS_DEFAULT_REGION', 'us-east-1'))
         self.conn = boto3.client(
             'ses',
             aws_access_key_id=access_key_id,

--- a/django_amazon_ses.py
+++ b/django_amazon_ses.py
@@ -27,9 +27,19 @@ class EmailBackend(BaseEmailBackend):
 
         """
         super(EmailBackend, self).__init__(fail_silently=fail_silently)
-        access_key_id = getattr(settings, 'AWS_SES_ACCESS_KEY_ID', getattr(settings, 'AWS_ACCESS_KEY_ID', None))
-        secret_access_key = getattr(settings, 'AWS_SES_SECRET_ACCESS_KEY', getattr(settings, 'AWS_SECRET_ACCESS_KEY', None))
-        region_name = getattr(settings, 'AWS_SES_REGION', getattr(settings, 'AWS_DEFAULT_REGION', 'us-east-1'))
+
+        # Get configuration from AWS default settings
+        access_key_id = getattr(settings, 'AWS_ACCESS_KEY_ID', None)
+        secret_access_key = getattr(settings, 'AWS_SECRET_ACCESS_KEY', None)
+        region_name = getattr(settings, 'AWS_DEFAULT_REGION', 'us-east-1')
+
+        # Override configuration with AWS SES-specific settings
+        access_key_id = getattr(settings, 'AWS_SES_ACCESS_KEY_ID',
+                                access_key_id)
+        secret_access_key = getattr(settings, 'AWS_SES_SECRET_ACCESS_KEY',
+                                    secret_access_key)
+        region_name = getattr(settings, 'AWS_SES_REGION', region_name)
+        
         self.conn = boto3.client(
             'ses',
             aws_access_key_id=access_key_id,

--- a/django_amazon_ses.py
+++ b/django_amazon_ses.py
@@ -39,7 +39,7 @@ class EmailBackend(BaseEmailBackend):
         secret_access_key = getattr(settings, 'AWS_SES_SECRET_ACCESS_KEY',
                                     secret_access_key)
         region_name = getattr(settings, 'AWS_SES_REGION', region_name)
-        
+
         self.conn = boto3.client(
             'ses',
             aws_access_key_id=access_key_id,


### PR DESCRIPTION
In cases the AWS settings have to be different for SES than for other AWS services, it is useful to have finer control on the access key id, secret key and region name. One use case is when S3 is set for a region where SES is not available.  

Therefore, I have added that, by default, AWS_SES_ACCESS_KEY_ID, AWS_SES_SECRET_ACCESS_KEY, AWS_SES_REGION are used. If they are not set, AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_DEFAULT_REGION will be used instead. 

This is similar to what is done in the [django-ses](https://github.com/django-ses/django-ses) package. 

PS: This is my first pull request ever, I hope I did everything correctly. 