### PR TITLE
Drop support for Django < 1.11

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,8 @@
+UNRELEASED
+==========
+
+- Remove support for Django < 1.11.
+
 1.0.0 - 2017-12-07
 ==================
 

--- a/setup.py
+++ b/setup.py
@@ -21,9 +21,6 @@ setup(
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Framework :: Django',
-        'Framework :: Django :: 1.8',
-        'Framework :: Django :: 1.9',
-        'Framework :: Django :: 1.10',
         'Framework :: Django :: 1.11',
         'Framework :: Django :: 2.0',
         'Intended Audience :: Developers',
@@ -38,5 +35,8 @@ setup(
     ],
     keywords='django amazon ses email',
     py_modules=['django_amazon_ses'],
-    install_requires=['boto3 >= 1.3.0'],
+    install_requires=[
+        'boto3 >= 1.3.0',
+        'Django >= 1.11',
+    ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,16 +1,11 @@
 [tox]
 envlist =
-       {py27,py34,py35}-django18,
-       {py27,py34,py35}-django{19,110},
        {py27,py34,py35,py36}-django111,
        {py34,py35,py36}-django20,
        {py35,py36}-djangomaster
 
 [testenv]
 deps =
-    django18: Django>=1.8,<1.9
-    django19: Django>=1.9,<1.10
-    django110: Django>=1.10,<1.11
     django111: Django>=1.11,<2.0
     django20: Django>=2.0,<2.1
     djangomaster: https://github.com/django/django/archive/master.tar.gz


### PR DESCRIPTION
Per Django's recommendation, now that django-amazon-ses supports 2.0, it
should drop support for Django < 1.11 to ease maintenance and
compatibility across Django versions. So long as no deprecation warnings
are produced, django-amazon-ses should remain forward compatible with
the next Django version.

For more details, see the Django docs:

https://docs.djangoproject.com/en/2.0/releases/2.0/#third-party-library-support-for-older-version-of-django

> Third-party library support for older version of Django
>
> Following the release of Django 2.0, we suggest that third-party app authors
> drop support for all versions of Django prior to 1.11. At that time, you
> should be able to run your package’s tests using python -Wd so that
> deprecation warnings do appear. After making the deprecation warning fixes,
> your app should be compatible with Django 2.0.

Those wishing to continue using an older Django can pin the version
django-amazon-ses.

Should reduce test suite runtime as it will no longer be running tests
against unsupported Django versions.