### PR TITLE
Allow key override in constructor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ __pycache__/
 .tox
 .cache
 .eggs
+.vscode/settings.json

--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,3 @@ __pycache__/
 .tox
 .cache
 .eggs
-.vscode/settings.json

--- a/django_amazon_ses.py
+++ b/django_amazon_ses.py
@@ -19,7 +19,8 @@ class EmailBackend(BaseEmailBackend):
         conn: A client connection for Amazon SES.
     """
 
-    def __init__(self, fail_silently=False, aws_access_key_id=None, aws_secret_access_key=None, ** kwargs):
+    def __init__(self, fail_silently=False, aws_access_key_id=None,
+                 aws_secret_access_key=None, ** kwargs):
         """Creates a client for the Amazon SES API.
 
         Args:
@@ -42,10 +43,10 @@ class EmailBackend(BaseEmailBackend):
         region_name = getattr(settings, 'AWS_SES_REGION', region_name)
 
         # Override if configuration are provided through constructor
-        if aws_access_key_id and aws_secret_access_key:
+        if (aws_access_key_id is not None and
+                aws_secret_access_key is not None):
             access_key_id = aws_access_key_id
             secret_access_key = aws_secret_access_key
-
 
         self.conn = boto3.client(
             'ses',

--- a/django_amazon_ses.py
+++ b/django_amazon_ses.py
@@ -18,7 +18,8 @@ class EmailBackend(BaseEmailBackend):
     Attributes:
         conn: A client connection for Amazon SES.
     """
-    def __init__(self, fail_silently=False, **kwargs):
+
+    def __init__(self, fail_silently=False, aws_access_key_id=None, aws_secret_access_key=None, ** kwargs):
         """Creates a client for the Amazon SES API.
 
         Args:
@@ -39,6 +40,12 @@ class EmailBackend(BaseEmailBackend):
         secret_access_key = getattr(settings, 'AWS_SES_SECRET_ACCESS_KEY',
                                     secret_access_key)
         region_name = getattr(settings, 'AWS_SES_REGION', region_name)
+
+        # Override if configuration are provided through constructor
+        if aws_access_key_id and aws_secret_access_key:
+            access_key_id = aws_access_key_id
+            secret_access_key = aws_secret_access_key
+
 
         self.conn = boto3.client(
             'ses',


### PR DESCRIPTION
It allows to use dynamic and multiple SES keys on runtime : 

```
from django.core import mail

aws_ses_access_key = 'my_access_key' # Fetch keys dynamically from secure store
aws_ses_secret_key = 'my_secret_key'
with mail.get_connection(aws_access_key_id=aws_ses_access_key,
                                     aws_secret_access_key=aws_ses_secret_key) as connection:
    mail.EmailMessage(
        subject1, body1, from1, [to1],
        connection=connection,
    ).send()
    mail.EmailMessage(
        subject2, body2, from2, [to2],
        connection=connection,
    ).send()
```