### PR TITLE
Make Moto able to mock Boto3 API calls

### DIFF
--- a/tests/test_boto.py
+++ b/tests/test_boto.py
@@ -1,6 +1,6 @@
 import boto3
 
-from moto import mock_ses
+from moto import mock_ses_deprecated
 try:
     from unittest import mock
 except ImportError:
@@ -19,7 +19,7 @@ settings.configure()
 
 class MailTests(SimpleTestCase):
 
-    @mock_ses
+    @mock_ses_deprecated
     def test_custom_backend(self):
         """Test Amazon SES backend."""
         client = boto3.client('ses', region_name='us-east-1')
@@ -32,7 +32,7 @@ class MailTests(SimpleTestCase):
         )
         self.assertGreater(conn.send_messages([email]), 0)
 
-    @mock_ses
+    @mock_ses_deprecated
     @mock.patch("django_amazon_ses.pre_send.send")
     def test_signal_pre(self, mock_signal):
         client = boto3.client('ses', region_name='us-east-1')
@@ -48,7 +48,7 @@ class MailTests(SimpleTestCase):
         self.assertIn('message', called_kwargs)
         self.assertEqual(email, called_kwargs['message'])
 
-    @mock_ses
+    @mock_ses_deprecated
     @mock.patch("django_amazon_ses.post_send.send")
     def test_signal_post(self, mock_signal):
         client = boto3.client('ses', region_name='us-east-1')
@@ -69,7 +69,7 @@ class MailTests(SimpleTestCase):
             r'\w{16,16}-\w{8,8}-\w{4,4}-\w{4,4}-\w{4,4}-\w{12,12}-\w{6,6}'
         )
 
-    @mock_ses
+    @mock_ses_deprecated
     def test_pre_change_recipients(self):
         new_email_address = 'changed@example.com'
 
@@ -89,7 +89,7 @@ class MailTests(SimpleTestCase):
         conn.send_messages([email])
         self.assertEqual(email.to, [new_email_address])
 
-    @mock_ses
+    @mock_ses_deprecated
     def test_pre_remove_recipients(self):
         def remove_recipients(sender, message=None, **kwargs):
             message.to = []


### PR DESCRIPTION
Boto3 v1.8+ replaced `requests` with `urllib3`, which broke the way Moto was mocking components of Boto3.

The deprecated Moto decorators used in this change set mock at the socket level, which allow it to bypass details about the HTTP client used. This approach is not ideal, but more desirable than the alternative of pinning Boto<1.8.

See:

- https://github.com/spulec/moto/issues/1793
- https://github.com/boto/botocore/pull/1495

---

**Testing**

See: https://travis-ci.org/azavea/django-amazon-ses/builds/429608546
