### PR TITLE
Add support and testing for Django 2.2

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,7 +1,7 @@
 UNRELEASED
 ==========
 
-- Added support and testing for Django 2.1 and Python 3.7. No actual code
+- Add support and testing for Django 2.1, 2.2 and Python 3.7. No actual code
   changes were required.
 
 2.0.0 - 2018-04-10

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ setup(
         'Framework :: Django :: 1.11',
         'Framework :: Django :: 2.0',
         'Framework :: Django :: 2.1',
+        'Framework :: Django :: 2.2',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: Apache Software License',
         'Programming Language :: Python',

--- a/tox.ini
+++ b/tox.ini
@@ -1,15 +1,17 @@
 [tox]
 envlist =
-       py{27,34,35,36,37}-django111,
-       py{34,35,36,37}-django20,
-       py{35,36,37}-django21,
-       py{35,36,37}-djangomaster
+       py{27,34,35,36,37}-django111
+       py{34,35,36,37}-django20
+       py{35,36,37}-django21
+       py{35,36,37}-django22
+       py{36,37}-djangomaster
 
 [testenv]
 deps =
     django111: Django>=1.11,<2.0
     django20: Django>=2.0,<2.1
     django21: Django>=2.1,<2.2
+    django22: Django>=2.2,<2.3
     djangomaster: https://github.com/django/django/archive/master.tar.gz
     check-manifest
     flake8


### PR DESCRIPTION
Announcement:
https://www.djangoproject.com/weblog/2019/apr/01/django-22-released/

Release notes:
https://docs.djangoproject.com/en/2.2/releases/2.2/

Django master no longer supports Python 3.5.