### PR TITLE
Add support for silencing botocore errors.

### DIFF
--- a/django_amazon_ses.py
+++ b/django_amazon_ses.py
@@ -1,7 +1,7 @@
 """Boto3 email backend class for Amazon SES."""
 import boto3
 
-from botocore.exceptions import ClientError
+from botocore.exceptions import BotoCoreError, ClientError
 
 from django.conf import settings
 from django.core.mail.backends.base import BaseEmailBackend
@@ -113,7 +113,7 @@ class EmailBackend(BaseEmailBackend):
                 message=email_message,
                 message_id=message_id
             )
-        except ClientError:
+        except (ClientError, BotoCoreError):
             if not self.fail_silently:
                 raise
             return False


### PR DESCRIPTION
In the past we have use `django-ses`, and we experienced several issues when errors occurred in the underlying `boto` library, which weren't properly suppressed when using `fail_silently`. 

Your package looks promising, but your also not silencing all errors from boto3 / botocore. I added support for generic botocore exceptions, and added a test.

I'm still curious why you were handling `ClientErrors` but not others.