### PR TITLE
Add Django 3.x support to test suite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,10 +13,7 @@ python:
   - "3.5"
   - "3.6"
   - "3.7"
-
-before_install:
-  # Workaround Travis environment.
-  - sudo rm /etc/boto.cfg
+  - "3.8"
 
 install: pip install tox-travis
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,9 @@
 UNRELEASED
 ==========
 
+- Add support for Django 3.x and Python 3.8. No actual code changes were
+  required.
+
 2.1.1 - 2019-06-08
 ==================
 

--- a/setup.py
+++ b/setup.py
@@ -35,9 +35,10 @@ setup(
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
     ],
     keywords="django amazon ses email",
     py_modules=["django_amazon_ses"],
-    install_requires=["boto3 >= 1.3.0", "Django >= 1.11"],
+    install_requires=["boto3>=1.3.0", "Django>=1.11,<3.1",],
     python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*",
 )

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,6 @@ setup(
     ],
     keywords="django amazon ses email",
     py_modules=["django_amazon_ses"],
-    install_requires=["boto3>=1.3.0", "Django>=1.11,<3.1",],
+    install_requires=["boto3>=1.3.0", "Django>=1.11,<3.1"],
     python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*",
 )

--- a/tox.ini
+++ b/tox.ini
@@ -3,8 +3,9 @@ envlist =
     py{27,34,35,36,37}-django111
     py{34,35,36,37}-django20
     py{35,36,37}-django21
-    py{35,36,37}-django22
-    py{36,37}-djangomaster
+    py{35,36,37,38}-django22
+    py{36,37,38}-django30
+    py{36,37,38}-djangomaster
 
 [testenv]
 deps =
@@ -12,6 +13,7 @@ deps =
     django20: Django>=2.0,<2.1
     django21: Django>=2.1,<2.2
     django22: Django>=2.2,<2.3
+    django30: Django>=3.0,<3.1
     djangomaster: https://github.com/django/django/archive/master.tar.gz
     check-manifest
     flake8


### PR DESCRIPTION
Make sure that our current suite of tests pass with Django 3.x, and by extension, Python 3.8.

---

**Testing**

See: https://travis-ci.org/azavea/django-amazon-ses/builds/620155840