### PR TITLE
Drop support for Python 2.7 and 3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,6 @@ env:
     - CC_TEST_REPORTER_ID=f803b9ba86041d642b4dbe476ac2faa72be48478b22b4264b8f4a8c0f920fda7
 
 python:
-  - "2.7"
-  - "3.4"
   - "3.5"
   - "3.6"
   - "3.7"

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,8 @@ UNRELEASED - 2019-08-08
   required.
 - Add ``AWS_SES_CONFIGURATION_SET_NAME`` option to use a specific SES
   configuration set.
+- Drop support for Python 2.7 and 3.4.
+- Fix double invocation of post message send signal.
 
 2.1.1 - 2019-06-08
 ==================

--- a/setup.py
+++ b/setup.py
@@ -28,10 +28,7 @@ setup(
         "Intended Audience :: Developers",
         "License :: OSI Approved :: Apache Software License",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 2",
-        "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
@@ -40,5 +37,5 @@ setup(
     keywords="django amazon ses email",
     py_modules=["django_amazon_ses"],
     install_requires=["boto3>=1.3.0", "Django>=1.11,<3.1"],
-    python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*",
+    python_requires=">2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*",
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
-    py{27,34,35,36,37}-django111
-    py{34,35,36,37}-django20
+    py{35,36,37}-django111
+    py{35,36,37}-django20
     py{35,36,37}-django21
     py{35,36,37,38}-django22
     py{36,37,38}-django30


### PR DESCRIPTION
Although Python 2.7 and 3.4 are still supported by earlier versions of Django, drop support within the module and its associated test suite. This decision was made because of repeated issues with dependency resolution in transitive dependencies.

Fixes https://github.com/azavea/django-amazon-ses/issues/50 with the changes included in 84ad28d80ab0bd5c7372a1be95db20fb01aca033.

---

**Testing**

See: https://travis-ci.org/azavea/django-amazon-ses/builds/637402806