### PR TITLE
Apply Python 3 code cleanups

### DIFF
--- a/django_amazon_ses.py
+++ b/django_amazon_ses.py
@@ -33,7 +33,7 @@ class EmailBackend(BaseEmailBackend):
                 client errors should throw an exception.
 
         """
-        super(EmailBackend, self).__init__(fail_silently=fail_silently)
+        super().__init__(fail_silently=fail_silently)
 
         # Get configuration from AWS prefixed settings in settings.py
         access_key_id = getattr(settings, "AWS_ACCESS_KEY_ID", None)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,3 @@
-[bdist_wheel]
-universal = 1
-
 [metadata]
 license_file = LICENSE.txt
 

--- a/tests/test_boto.py
+++ b/tests/test_boto.py
@@ -3,10 +3,7 @@ from botocore.exceptions import NoCredentialsError
 
 from moto import mock_ses_deprecated
 
-try:
-    from unittest import mock
-except ImportError:
-    import mock
+from unittest import mock
 
 from django.conf import settings
 from django.core import mail

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,6 @@ deps =
     check-manifest
     flake8
     readme_renderer
-    mock
     moto>=0.4.23
     pytest-runner
     pytest-cov


### PR DESCRIPTION
- Can use shorter super() syntax.
- Can use stdlib unittest.mock and drop dependency.
- The wheel is no longer universal as it doesn't support Python 2.