### PR TITLE
Remove deprecated pytest-runner

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,2 @@
 [metadata]
 license_file = LICENSE.txt
-
-[aliases]
-test = pytest

--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,6 @@ deps =
     flake8
     readme_renderer
     moto>=0.4.23
-    pytest-runner
     pytest-cov
     pytest
 
@@ -27,8 +26,7 @@ commands =
     check-manifest --ignore tox.ini
     {envpython} setup.py check -m -r -s
     flake8 . --max-line-length=100
-    {envpython} setup.py test
-    {envpython} setup.py test --addopts="--cov-report=xml --cov=django_amazon_ses tests/"
+    pytest --cov-report=xml --cov=django_amazon_ses
 
 [flake8]
 exclude = .tox,*.egg,build,data


### PR DESCRIPTION
Per the pytest-runner README, the package is deprecated and should not
be used:

https://github.com/pytest-dev/pytest-runner

The package unnecessary to run tests anyway. So slightly speed up test
execution by dropping the dependency.

Can also avoid running the same test suite twice to speed up test
execution.