### PR TITLE
Simplify flake8 configuration

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -29,7 +29,3 @@ commands =
     flake8 . --max-line-length=100
     {envpython} setup.py test
     {envpython} setup.py test --addopts="--cov-report=xml --cov=django_amazon_ses tests/"
-
-[flake8]
-exclude = .tox,*.egg,build,data
-select = E,W,F


### PR DESCRIPTION
The exclude directories either don't exist or are excluded by default by
flake8.

https://gitlab.com/pycqa/flake8/blob/master/src/flake8/defaults.py#L4-14

Run all flake8 warnings available.