### PR TITLE
Fix send_message() to return 0 when passed an empty list

### DIFF
--- a/django_amazon_ses.py
+++ b/django_amazon_ses.py
@@ -76,7 +76,7 @@ class EmailBackend(BaseEmailBackend):
                 failed.
         """
         if not email_messages:
-            return
+            return 0
 
         sent_message_count = 0
 

--- a/tests/test_boto.py
+++ b/tests/test_boto.py
@@ -142,3 +142,8 @@ class MailTests(SimpleTestCase):
         conn.fail_silently = True
         message_sent = conn.send_messages([email])
         self.assertFalse(message_sent)
+
+    @mock_ses_deprecated
+    def test_send_messages_empty_list(self):
+        conn = mail.get_connection("django_amazon_ses.EmailBackend")
+        self.assertEqual(conn.send_messages([]), 0)


### PR DESCRIPTION
Now matches Django's behavior:

https://github.com/django/django/blob/c7b97ac3a7908dab0825f6bdb61b40f641306a8e/django/core/mail/backends/smtp.py#L99-L100