### PR TITLE
Clean up deprecated/default Travis CI options

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,3 @@
-dist: xenial
-sudo: false
 language: python
 cache: pip
 


### PR DESCRIPTION
The sudo option was deprecated:

https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration

Ubuntu Xenial is now the default environment and does not need to be
specified.

https://blog.travis-ci.com/2019-04-15-xenial-default-build-environment