### PR TITLE
Move lint commands to own tox & Travis stage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,10 @@ python:
   - "3.7"
   - "3.8"
 
+matrix:
+  include:
+    - env: TOXENV=lint
+
 install: pip install tox-travis
 
 before_script:

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,6 @@
 [tox]
 envlist =
+    lint
     py{35,36,37}-django111
     py{35,36,37}-django20
     py{35,36,37}-django21
@@ -15,20 +16,24 @@ deps =
     django22: Django>=2.2,<2.3
     django30: Django>=3.0,<3.1
     djangomaster: https://github.com/django/django/archive/master.tar.gz
-    check-manifest
-    flake8
-    readme_renderer
     moto>=0.4.23
     pytest-runner
     pytest-cov
     pytest
+commands =
+    {envpython} setup.py test
+    {envpython} setup.py test --addopts="--cov-report=xml --cov=django_amazon_ses tests/"
 
+[testenv:lint]
+deps =
+    check-manifest
+    flake8
+    readme_renderer
 commands =
     check-manifest --ignore tox.ini
     {envpython} setup.py check -m -r -s
     flake8 . --max-line-length=100
-    {envpython} setup.py test
-    {envpython} setup.py test --addopts="--cov-report=xml --cov=django_amazon_ses tests/"
+skip_install = true
 
 [flake8]
 exclude = .tox,*.egg,build,data


### PR DESCRIPTION
This helps speed up the tox and Travis runs by running the lint commands
in parallel to the test commands. The lint commands need only be run
once for the project, not once for every support Python variation. This
reduces the necessary dependencies for running the tests without running
the lint commands. As linting doesn't require installing the library,
use tox option skip_install to save an additional small amount of time.