### PR TITLE
Allow testing against Django master branch

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -36,4 +36,4 @@ py_modules = django_amazon_ses
 python_requires = >=3.5
 install_requires =
     boto3 >=1.3.0
-    Django >=1.11, <3.1
+    Django >=1.11


### PR DESCRIPTION
Previously, when testing against Django master, due to the pinned
version constraint, tox would downgrade Django to a 3.0.x. For example,
observe the following output:

    $ tox -e py38-djangomaster
    GLOB sdist-make: /home/jon/devel/django-amazon-ses/setup.py
    py38-djangomaster create: /home/jon/devel/django-amazon-ses/.tox/py38-djangomaster
    py38-djangomaster installdeps: https://github.com/django/django/archive/master.tar.gz, moto>=1.0.0, pytest-cov, pytest
    py38-djangomaster inst: /home/jon/devel/django-amazon-ses/.tox/.tmp/package/1/django-amazon-ses-3.0.2.zip
    py38-djangomaster installed: asgiref==3.2.3,attrs==19.3.0,aws-sam-translator==1.20.1,aws-xray-sdk==2.4.3,boto==2.49.0,boto3==1.11.12,botocore==1.14.12,certifi==2019.11.28,cffi==1.13.2,cfn-lint==0.27.4,chardet==3.0.4,coverage==5.0.3,cryptography==2.8,Django==3.0.3,django-amazon-ses==3.0.2,docker==4.2.0,docutils==0.15.2,ecdsa==0.15,future==0.18.2,idna==2.8,Jinja2==2.11.1,jmespath==0.9.4,jsondiff==1.1.2,jsonpatch==1.25,jsonpickle==1.2,jsonpointer==2.0,jsonschema==3.2.0,MarkupSafe==1.1.1,mock==4.0.1,more-itertools==8.2.0,moto==1.3.14,packaging==20.1,pluggy==0.13.1,py==1.8.1,pyasn1==0.4.8,pycparser==2.19,pyparsing==2.4.6,pyrsistent==0.15.7,pytest==5.3.5,pytest-cov==2.8.1,python-dateutil==2.8.1,python-jose==3.1.0,pytz==2019.3,PyYAML==5.3,requests==2.22.0,responses==0.10.9,rsa==4.0,s3transfer==0.3.3,six==1.14.0,sqlparse==0.3.0,sshpubkeys==3.1.0,urllib3==1.25.8,wcwidth==0.1.8,websocket-client==0.57.0,Werkzeug==1.0.0,wrapt==1.11.2,xmltodict==0.12.0
    ...

Notice on the last line, Django is re-installed with version
Django==3.0.3. So the master branch was not actually being tested.

With this change, now the output is:

    $ tox -e py38-djangomaster
    GLOB sdist-make: /home/jon/devel/django-amazon-ses/setup.py
    py38-djangomaster create: /home/jon/devel/django-amazon-ses/.tox/py38-djangomaster
    py38-djangomaster installdeps: https://github.com/django/django/archive/master.tar.gz, moto>=1.0.0, pytest-cov, pytest
    py38-djangomaster inst: /home/jon/devel/django-amazon-ses/.tox/.tmp/package/1/django-amazon-ses-3.0.2.zip
    py38-djangomaster installed: asgiref==3.2.3,attrs==19.3.0,aws-sam-translator==1.20.1,aws-xray-sdk==2.4.3,boto==2.49.0,boto3==1.11.12,botocore==1.14.12,certifi==2019.11.28,cffi==1.13.2,cfn-lint==0.27.4,chardet==3.0.4,coverage==5.0.3,cryptography==2.8,Django==3.1,django-amazon-ses==3.0.2,docker==4.2.0,docutils==0.15.2,ecdsa==0.15,future==0.18.2,idna==2.8,Jinja2==2.11.1,jmespath==0.9.4,jsondiff==1.1.2,jsonpatch==1.25,jsonpickle==1.2,jsonpointer==2.0,jsonschema==3.2.0,MarkupSafe==1.1.1,mock==4.0.1,more-itertools==8.2.0,moto==1.3.14,packaging==20.1,pluggy==0.13.1,py==1.8.1,pyasn1==0.4.8,pycparser==2.19,pyparsing==2.4.6,pyrsistent==0.15.7,pytest==5.3.5,pytest-cov==2.8.1,python-dateutil==2.8.1,python-jose==3.1.0,pytz==2019.3,PyYAML==5.3,requests==2.22.0,responses==0.10.9,rsa==4.0,s3transfer==0.3.3,six==1.14.0,sqlparse==0.3.0,sshpubkeys==3.1.0,urllib3==1.25.8,wcwidth==0.1.8,websocket-client==0.57.0,Werkzeug==1.0.0,wrapt==1.11.2,xmltodict==0.12.0

Notice the last line now contains Django==3.1. And so it is testing
against the master branch.

This helps ensures the project remains compatible with Django as it
evolves.