### PR TITLE
Drop EOL Django versions from the test matrix

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,11 @@
 UNRELEASED - 2020-01-19
 =======================
 
+UNRELEASED
+==========
+
+- Remove support for end-of-life Django 2.0 and 2.1.
+
 3.0.2 - 2020-01-19
 ==================
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,8 +12,6 @@ classifiers =
     Development Status :: 5 - Production/Stable
     Framework :: Django
     Framework :: Django :: 1.11
-    Framework :: Django :: 2.0
-    Framework :: Django :: 2.1
     Framework :: Django :: 2.2
     Framework :: Django :: 3.0
     Intended Audience :: Developers

--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,6 @@
 envlist =
     lint
     py{35,36,37}-django111
-    py{35,36,37}-django20
-    py{35,36,37}-django21
     py{35,36,37,38}-django22
     py{36,37,38}-django30
     py{36,37,38}-djangomaster


### PR DESCRIPTION
Django 2.0 when end-of-life April 1, 2019 and 2.1 on December 2, 2019.
For more details on supported versions of Django, see:

https://www.djangoproject.com/download/

By removing these EOL versions, it reduces time and resources needed to
complete testing.