### PR TITLE
Allow assume role in construction

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -108,6 +108,15 @@ Alternatively, provide AWS credentials using the settings below. This is useful 
     AWS_SES_SECRET_ACCESS_KEY = 'my_secret...'
     AWS_SES_REGION = 'us-west-2'
 
+If you want SES to assume a specific role when sending email you can the configuration below.
+```AWS_SES_EXTERNAL_ID``` is optional depending on your role requirements.
+If you specify an AWS access key/secret key in your configuration, it will use those in the AssumeRole API call and the temporary credentials in the SES API call.
+
+.. code:: python
+
+    AWS_SES_ROLE_ARN = 'arn:aws:iam::210987654321:role/ses_role'
+    AWS_SES_EXTERNAL_ID = 'd87e5499-00ec-4b16-a821-b59ec6d2e097'
+
 If you want to force the use of a SES configuration set you can set the option below.
 This is useful when you want to do more detailed tracking of your emails such as opens and clicks. You can see more details at: https://docs.aws.amazon.com/ses/latest/DeveloperGuide/using-configuration-sets.html.
 

--- a/django_amazon_ses.py
+++ b/django_amazon_ses.py
@@ -25,7 +25,6 @@ class EmailBackend(BaseEmailBackend):
         fail_silently=False,
         aws_access_key_id=None,
         aws_secret_access_key=None,
-        aws_session_token=None,
         **kwargs
     ):
         """Creates a client for the Amazon SES API.
@@ -82,7 +81,7 @@ class EmailBackend(BaseEmailBackend):
         if aws_access_key_id is not None and aws_secret_access_key is not None:
             access_key_id = aws_access_key_id
             secret_access_key = aws_secret_access_key
-            session_token = aws_session_token
+            session_token = kwargs.get('aws_session_token', None)
 
         self.conn = boto3.client(
             "ses",

--- a/tests/test_boto.py
+++ b/tests/test_boto.py
@@ -17,6 +17,7 @@ settings.configure()
 
 ROLE_ARN = 'arn:aws:iam::210987654321:role/ses_role'
 
+
 @override_settings(AWS_SES_ROLE_ARN=ROLE_ARN)
 class AssumeRoleTests(SimpleTestCase):
     @mock_sts
@@ -41,7 +42,7 @@ class AssumeRoleTests(SimpleTestCase):
         """We raise an exception on failure to assume role."""
         with self.assertRaises(ParamValidationError) as e:
             with override_settings(AWS_SES_ROLE_ARN='bad'):
-                conn = mail.get_connection("django_amazon_ses.EmailBackend")
+                mail.get_connection("django_amazon_ses.EmailBackend")
         self.assertIn('Invalid length for parameter RoleArn', str(e.exception))
 
     @mock_sts
@@ -67,7 +68,7 @@ class AssumeRoleTests(SimpleTestCase):
         """We raise an exception on failure to assume role with external id."""
         with self.assertRaises(ParamValidationError) as e:
             with override_settings(AWS_SES_EXTERNAL_ID='0'):
-                conn = mail.get_connection("django_amazon_ses.EmailBackend")
+                mail.get_connection("django_amazon_ses.EmailBackend")
         self.assertIn('Invalid length for parameter ExternalId', str(e.exception))
 
 


### PR DESCRIPTION
This adds the ability to specify an `AWS_SES_ROLE_ARN` in the settings file (as well as a `AWS_SES_EXTERNAL_ID`, if needed). If the role ARN is specified it will use the provided access key/secret key to assume the role, then connect to SES based on that result.

Closes: https://github.com/azavea/django-amazon-ses/issues/62