### PR TITLE
Update setup.cfg to support current Django versions

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,8 @@ UNRELEASED - 2020-01-19
 UNRELEASED
 ==========
 
-- Remove support for end-of-life Django 2.0 and 2.1.
+- Add support for Django 3.1.
+- Remove support for end-of-life Django 1.11, 2.0 and 2.1.
 
 3.0.2 - 2020-01-19
 ==================

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,9 +11,9 @@ license_file = LICENSE.txt
 classifiers =
     Development Status :: 5 - Production/Stable
     Framework :: Django
-    Framework :: Django :: 1.11
     Framework :: Django :: 2.2
     Framework :: Django :: 3.0
+    Framework :: Django :: 3.1
     Intended Audience :: Developers
     License :: OSI Approved :: Apache Software License
     Programming Language :: Python
@@ -34,4 +34,4 @@ py_modules = django_amazon_ses
 python_requires = >=3.5
 install_requires =
     boto3 >=1.3.0
-    Django >=1.11
+    Django >=2.2

--- a/tox.ini
+++ b/tox.ini
@@ -1,18 +1,16 @@
 [tox]
 envlist =
     lint
-    py{35,36,37}-django111
     py{35,36,37,38}-django22
     py{36,37,38}-django30
+    py{36,37,38}-django31
     py{36,37,38}-djangomaster
 
 [testenv]
 deps =
-    django111: Django>=1.11,<2.0
-    django20: Django>=2.0,<2.1
-    django21: Django>=2.1,<2.2
     django22: Django>=2.2,<2.3
     django30: Django>=3.0,<3.1
+    django31: Django>=3.1,<3.2
     djangomaster: https://github.com/django/django/archive/master.tar.gz
     moto>=1.0.0
     pytest-cov


### PR DESCRIPTION
Updated the Django dependency to require version 2.2, 3.0 or 3.1, which are the currently supported versions (https://www.djangoproject.com/download/).