### PR TITLE
Simplify flake8 configuration

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -39,4 +39,4 @@ skip_install = true
 
 [flake8]
 max-line-length = 88
-extend-ignore = E203, W503
+extend-ignore = E203


### PR DESCRIPTION
W503 is ignored by default:
https://pycodestyle.pycqa.org/en/latest/intro.html#error-codes

> In the default configuration, the checks E121, E123, E126, E133, E226,
> E241, E242, E704, W503, W504 and W505 are ignored because they are not
> rules unanimously accepted, and PEP 8 does not enforce them.