### PR TITLE
Remove deprecated providing_args argument

### DIFF
--- a/django_amazon_ses.py
+++ b/django_amazon_ses.py
@@ -8,8 +8,8 @@ from django.core.mail.backends.base import BaseEmailBackend
 from django.core.mail.message import sanitize_address
 from django.dispatch import Signal
 
-pre_send = Signal(providing_args=["message"])
-post_send = Signal(providing_args=["message", "message_id"])
+pre_send = Signal()
+post_send = Signal()
 
 
 class EmailBackend(BaseEmailBackend):


### PR DESCRIPTION
Deprecated since upstream commit:
https://github.com/django/django/commit/769cee525222bb155735aba31d6174d73c271f3c

Fixes warning when running the test suite:

    django_amazon_ses.py:11
      django-amazon-ses/django_amazon_ses.py:11: RemovedInDjango40Warning: The providing_args argument is deprecated. As it is purely documentational, it has no replacement. If you rely on this argument as documentation, you can move the text to a code comment or docstring.
        pre_send = Signal(providing_args=["message"])

    django_amazon_ses.py:12
      django-amazon-ses/django_amazon_ses.py:12: RemovedInDjango40Warning: The providing_args argument is deprecated. As it is purely documentational, it has no replacement. If you rely on this argument as documentation, you can move the text to a code comment or docstring.
        post_send = Signal(providing_args=["message", "message_id"])