### PR TITLE
Allow tagging emails sent with SES

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,7 +5,7 @@ Unreleased
 - Add Python 3.9 and 3.10 to the test matrix.
 - Add Django 3.2 and 4.0 to the test matrix.
 - Remove support for end-of-life Django 3.0 and 3.1.
-
+- Add ability to tag emails
 
 4.0.0 - 2020-08-25
 ==================

--- a/django_amazon_ses.py
+++ b/django_amazon_ses.py
@@ -49,6 +49,7 @@ class EmailBackend(BaseEmailBackend):
         self.configuration_set_name = getattr(
             settings, "AWS_SES_CONFIGURATION_SET_NAME", None
         )
+        self.tags = getattr(settings, "AWS_SES_TAGS", None)
 
         # Override all previous configuration if settings provided
         # through the constructor
@@ -117,6 +118,8 @@ class EmailBackend(BaseEmailBackend):
 
             if self.configuration_set_name is not None:
                 kwargs["ConfigurationSetName"] = self.configuration_set_name
+            if self.tags is not None:
+                kwargs["Tags"] = self.tags
 
             result = self.conn.send_raw_email(**kwargs)
             message_id = result["MessageId"]


### PR DESCRIPTION
https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ses.html#SES.Client.send_raw_email

The tags can be used in AWS services, such as CloudWatch, to group
emails and create reports and alarms. In my use case (multi-tenancy), it
would allow following the origin of SES emails.