### PR TITLE
Replace deprecated setup.py check with twine

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -3,6 +3,7 @@ name = django-amazon-ses
 version = 4.0.0
 description = A Django email backend that uses Boto3 to interact with Amazon Simple Email Service (SES).
 long_description = file: README.rst
+long_description_content_type = text/x-rst
 url = https://github.com/azavea/django-amazon-ses
 author = Hector Castro
 author_email = hcastro@azavea.com

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     lint
-
+    packaging
     py{37,38,39}-django22
     py{37,38}-django30
     py{37,38,39}-django31
@@ -12,7 +12,7 @@ python =
     3.7: py37, lint
     3.8: py38
     3.9: py39
-    3.10: py310
+    3.10: py310, packaging
 
 [testenv]
 deps =
@@ -34,10 +34,19 @@ deps =
     readme_renderer
 commands =
     check-manifest --ignore tox.ini
-    {envpython} setup.py check -m -r -s
     flake8 .
     black --check --diff .
 skip_install = true
+
+[testenv:packaging]
+deps =
+    setuptools
+    twine
+    wheel
+skip_install = true
+commands =
+    python setup.py sdist bdist_wheel
+    twine check --strict dist/*
 
 [flake8]
 max-line-length = 88


### PR DESCRIPTION
```
$ python setup.py check -m -s -r
running check
warning: Check: This command has been deprecated. Use `twine check` instead: https://packaging.python.org/guides/making-a-pypi-friendly-readme#validating-restructuredtext-markup
```