### PR TITLE
Point to Django main branch instead of master

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ envlist =
     py{37,38,39}-django22
     py{37,38}-django30
     py{37,38,39}-django31
-    py{39,310}-djangomaster
+    py{38,39,310}-djangomain
 
 [gh-actions]
 python =
@@ -19,7 +19,7 @@ deps =
     django22: Django>=2.2,<2.3
     django30: Django>=3.0,<3.1
     django31: Django>=3.1,<3.2
-    djangomaster: https://github.com/django/django/archive/master.tar.gz
+    djangomain: https://github.com/django/django/archive/main.tar.gz
     moto>=1.0.0
     pytest-cov
     pytest


### PR DESCRIPTION
The master branch was renamed to main.