### PR TITLE
Remove env variables from GH action tox invocation

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -35,6 +35,3 @@ jobs:
 
       - name: Run Tox
         run: tox
-        env:
-          PYTHONPATH: ./tests/
-          DJANGO_SETTINGS_MODULE: settings_test


### PR DESCRIPTION
Variables are not listed in the passenv tox directive and therefore
ignored.