### PR TITLE
Support cross-account SES sending via STS AssumeRole

### DIFF
--- a/django_amazon_ses.py
+++ b/django_amazon_ses.py
@@ -1,4 +1,6 @@
 """Boto3 email backend class for Amazon SES."""
+from datetime import datetime, timedelta, timezone
+
 import boto3
 
 from botocore.exceptions import BotoCoreError, ClientError
@@ -46,6 +48,10 @@ class EmailBackend(BaseEmailBackend):
             settings, "AWS_SES_SECRET_ACCESS_KEY", secret_access_key
         )
         region_name = getattr(settings, "AWS_SES_REGION", region_name)
+        self.assume_role_arn = getattr(settings, "AWS_SES_ASSUME_ROLE_ARN", None)
+        self.assume_region_name = getattr(
+            settings, "AWS_SES_ASSUME_REGION", "us-east-1"
+        )
         self.configuration_set_name = getattr(
             settings, "AWS_SES_CONFIGURATION_SET_NAME", None
         )
@@ -57,12 +63,22 @@ class EmailBackend(BaseEmailBackend):
             access_key_id = aws_access_key_id
             secret_access_key = aws_secret_access_key
 
-        self.conn = boto3.client(
-            "ses",
-            aws_access_key_id=access_key_id,
-            aws_secret_access_key=secret_access_key,
-            region_name=region_name,
-        )
+        if self.assume_role_arn:
+            self.sts_conn = boto3.client(
+                "sts",
+                aws_access_key_id=access_key_id,
+                aws_secret_access_key=secret_access_key,
+                region_name=region_name,
+            )
+
+            self.conn = None
+        else:
+            self.conn = boto3.client(
+                "ses",
+                aws_access_key_id=access_key_id,
+                aws_secret_access_key=secret_access_key,
+                region_name=region_name,
+            )
 
     def send_messages(self, email_messages):
         """Sends one or more EmailMessage objects and returns the
@@ -110,6 +126,25 @@ class EmailBackend(BaseEmailBackend):
         message = email_message.message().as_bytes(linesep="\r\n")
 
         try:
+            if self.assume_role_arn and (
+                not self.conn
+                or self.expiration - timedelta(minutes=5) <= datetime.now(timezone.utc)
+            ):
+                result = self.sts_conn.assume_role(
+                    RoleArn=self.assume_role_arn,
+                    RoleSessionName="django_amazon_ses",
+                )
+                credentials = result["Credentials"]
+                self.expiration = credentials["Expiration"]
+
+                self.conn = boto3.client(
+                    "ses",
+                    aws_access_key_id=credentials["AccessKeyId"],
+                    aws_secret_access_key=credentials["SecretAccessKey"],
+                    aws_session_token=credentials["SessionToken"],
+                    region_name=self.assume_region_name,
+                )
+
             kwargs = {
                 "Source": from_email,
                 "Destinations": recipients,


### PR DESCRIPTION
### Background

- In ECS environments, using AWS_PROFILE-based role assumption is not practical, so there is a need to explicitly assume a role in the application when sending SES email across AWS accounts.
- On EC2, profile-based AssumeRole can work, but long-lived worker processes (for example, Celery workers) may keep running past the STS session lifetime and fail after credentials expire.

### What this PR changes

- Adds optional STS AssumeRole support to the SES backend via AWS_SES_ASSUME_ROLE_ARN.
- Adds AWS_SES_ASSUME_REGION (default: us-east-1) for the SES target account/region.
- Uses lazy role assumption at send time and refreshes temporary credentials when close to expiration, so long-running workers can continue sending mail.

### Compatibility

- If AWS_SES_ASSUME_ROLE_ARN is not set, behavior remains unchanged from the existing backend.

### Validation

- Verified in a real AWS environment with appropriate IAM role permissions and trust relationships by successfully sending email via SES across accounts.